### PR TITLE
Add .circleci/config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,34 @@
+version: 2
+
+workflows:
+  version: 2
+  workflow:
+    jobs:
+      - test-2.7
+      - test-3.7
+
+defaults: &defaults
+  steps:
+  - checkout
+  - run:
+      name: Install dependencies
+      command: |
+        GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" \
+          sudo -E pip install -r requirements.txt
+  - run:
+      name: Test
+      command: python setup.py test
+
+jobs:
+  test-2.7:
+    <<: *defaults
+    docker:
+    - image: circleci/python:2.7
+    - image: mongo:3.2.19
+    - image: redis:3.2.6
+  test-3.7:
+    <<: *defaults
+    docker:
+    - image: circleci/python:3.7
+    - image: mongo:3.2.19
+    - image: redis:3.2.6

--- a/cachecow/mongo.py
+++ b/cachecow/mongo.py
@@ -31,6 +31,5 @@ class MongoCacheCow(CacheCow):
 
     def get_keys(self, cls, id_field, id_val):
         # store the data in redis under cache/flag:collection_name$id_field_name$id_value
-        key = xxhash.xxh64(b'%s$%s$%s' % (cls._get_collection_name(), id_field, id_val)).hexdigest()
+        key = xxhash.xxh64('%s$%s$%s' % (cls._get_collection_name(), id_field, id_val)).hexdigest()
         return 'cache:' + key, 'flag:' + key
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
--e git+ssh://git@github.com/closeio/mongoengine.git#egg=mongoengine-dev
-pymongo==2.8
-redis==2.10.3
+-e git+ssh://git@github.com/closeio/mongoengine.git@dcb75720445ea434506efa32d3aee596ce026426#egg=mongoengine
+pymongo==2.9.5
+redis==2.10.6
 xxhash==0.4.3


### PR DESCRIPTION
Closes #2

Tests wouldn't pass on `3.7` because of our mongoengine fork. I updated the dependencies and now tests pass on `2.7` and `3.7`. Not sure what the target here is...